### PR TITLE
Fix unit tests to avoid overflow

### DIFF
--- a/gca386-TestCollatz.c++
+++ b/gca386-TestCollatz.c++
@@ -26,77 +26,91 @@ using namespace std;
 // ----
 
 TEST(CollatzFixture, read) {
-    istringstream r("1 10\n");
-    int           i;
-    int           j;
-    const bool b = collatz_read(r, i, j);
-    ASSERT_TRUE(b);
-    ASSERT_EQ( 1, i);
-    ASSERT_EQ(10, j);}
+  istringstream r("1 10\n");
+  int i;
+  int j;
+  const bool b = collatz_read(r, i, j);
+  ASSERT_TRUE(b);
+  ASSERT_EQ(1, i);
+  ASSERT_EQ(10, j);
+}
 
 // ----
 // eval
 // ----
 
-TEST(CollatzFixture, eval_1) {
-    const int v = collatz_eval(1, 10);
-    ASSERT_EQ(20, v);}
-
 TEST(CollatzFixture, eval_2) {
-    const int v = collatz_eval(100, 200);
-    ASSERT_EQ(125, v);}
+  const int v = collatz_eval(100, 200);
+  ASSERT_EQ(125, v);
+}
 
 TEST(CollatzFixture, eval_3) {
-    const int v = collatz_eval(201, 210);
-    ASSERT_EQ(89, v);}
+  const int v = collatz_eval(201, 210);
+  ASSERT_EQ(89, v);
+}
 
 TEST(CollatzFixture, eval_4) {
-    const int v = collatz_eval(900, 1000);
-    ASSERT_EQ(174, v);}
+  const int v = collatz_eval(900, 1000);
+  ASSERT_EQ(174, v);
+}
 
 TEST(CollatzFixture, eval_5) {
-    const int v = collatz_eval(687871, 687871);
-    ASSERT_EQ(380, v);}
+  const int v = collatz_eval(17717, 21404);
+  ASSERT_EQ(274, v);
+}
 
 TEST(CollatzFixture, eval_6) {
-    const int v = collatz_eval(704511, 704511);
-    ASSERT_EQ(243, v);}
+  const int v = collatz_eval(28162, 81335);
+  ASSERT_EQ(351, v);
+}
 
 TEST(CollatzFixture, eval_7) {
-    const int v = collatz_eval(747291, 747291);
-    ASSERT_EQ(248, v);}
+  const int v = collatz_eval(18028, 22718);
+  ASSERT_EQ(274, v);
+}
 
 TEST(CollatzFixture, eval_8) {
-    const int v = collatz_eval(753663, 753663);
-    ASSERT_EQ(331, v);}
+  const int v = collatz_eval(20033, 40174);
+  ASSERT_EQ(324, v);
+}
 
 // -----
 // print
 // -----
 
 TEST(CollatzFixture, print) {
-    ostringstream w;
-    collatz_print(w, 1, 10, 20);
-    ASSERT_EQ("1 10 20\n", w.str());}
+  ostringstream w;
+  collatz_print(w, 1, 10, 20);
+  ASSERT_EQ("1 10 20\n", w.str());
+}
 
 // -----
 // solve
 // -----
 
 TEST(CollatzFixture, solve) {
-    istringstream r("1 10\n100 200\n201 210\n900 1000\n");
-    ostringstream w;
-    collatz_solve(r, w);
-    ASSERT_EQ("1 10 20\n100 200 125\n201 210 89\n900 1000 174\n", w.str());}
+  istringstream r("1 10\n100 200\n201 210\n900 1000\n");
+  ostringstream w;
+  collatz_solve(r, w);
+  ASSERT_EQ("1 10 20\n100 200 125\n201 210 89\n900 1000 174\n", w.str());
+}
 
+/**
+ * verifies that max_cycle_length(a, b) == max_cycle_length(b, a)
+ */
 TEST(CollatzFixture, solve_inverse) {
-    istringstream r("727364 50\n50 727364\n");
-    ostringstream w;
-    collatz_solve(r, w);
-    ASSERT_EQ("727364 50 509\n50 727364 509\n", w.str());}
+  istringstream r("4944 48637\n48637 4944\n");
+  ostringstream w;
+  collatz_solve(r, w);
+  ASSERT_EQ("4944 48637 324\n48637 4944 324\n", w.str());
+}
 
-TEST(CollatzFixture, solve_max_range) {
-    istringstream r("1 1000000\n");
-    ostringstream w;
-    collatz_solve(r, w);
-    ASSERT_EQ("1 1000000 525\n", w.str());}
+/**
+ * verifies that max_cycle_length(a, a) == cycle_length(a)
+ */
+TEST(CollatzFixture, solve_single) {
+  istringstream r("247272 247272\n");
+  ostringstream w;
+  collatz_solve(r, w);
+  ASSERT_EQ("247272 247272 94\n", w.str());
+}

--- a/gca386-TestCollatz.out
+++ b/gca386-TestCollatz.out
@@ -1,61 +1,59 @@
-==1511== Memcheck, a memory error detector
-==1511== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
-==1511== Using Valgrind-3.10.0 and LibVEX; rerun with -h for copyright info
-==1511== Command: ./TestCollatz
-==1511==
+==2433== Memcheck, a memory error detector
+==2433== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
+==2433== Using Valgrind-3.10.0 and LibVEX; rerun with -h for copyright info
+==2433== Command: ./TestCollatz
+==2433==
 Running main() from gtest_main.cc
-[==========] Running 13 tests from 1 test case.
+[==========] Running 12 tests from 1 test case.
 [----------] Global test environment set-up.
-[----------] 13 tests from CollatzFixture
+[----------] 12 tests from CollatzFixture
 [ RUN      ] CollatzFixture.read
-[       OK ] CollatzFixture.read (18 ms)
-[ RUN      ] CollatzFixture.eval_1
-[       OK ] CollatzFixture.eval_1 (6 ms)
+[       OK ] CollatzFixture.read (19 ms)
 [ RUN      ] CollatzFixture.eval_2
-[       OK ] CollatzFixture.eval_2 (2 ms)
+[       OK ] CollatzFixture.eval_2 (6 ms)
 [ RUN      ] CollatzFixture.eval_3
 [       OK ] CollatzFixture.eval_3 (2 ms)
 [ RUN      ] CollatzFixture.eval_4
 [       OK ] CollatzFixture.eval_4 (2 ms)
 [ RUN      ] CollatzFixture.eval_5
-[       OK ] CollatzFixture.eval_5 (2 ms)
+[       OK ] CollatzFixture.eval_5 (29 ms)
 [ RUN      ] CollatzFixture.eval_6
-[       OK ] CollatzFixture.eval_6 (2 ms)
+[       OK ] CollatzFixture.eval_6 (150 ms)
 [ RUN      ] CollatzFixture.eval_7
-[       OK ] CollatzFixture.eval_7 (2 ms)
+[       OK ] CollatzFixture.eval_7 (6 ms)
 [ RUN      ] CollatzFixture.eval_8
-[       OK ] CollatzFixture.eval_8 (1 ms)
+[       OK ] CollatzFixture.eval_8 (21 ms)
 [ RUN      ] CollatzFixture.print
-[       OK ] CollatzFixture.print (7 ms)
+[       OK ] CollatzFixture.print (6 ms)
 [ RUN      ] CollatzFixture.solve
-[       OK ] CollatzFixture.solve (5 ms)
+[       OK ] CollatzFixture.solve (6 ms)
 [ RUN      ] CollatzFixture.solve_inverse
-[       OK ] CollatzFixture.solve_inverse (1810 ms)
-[ RUN      ] CollatzFixture.solve_max_range
-[       OK ] CollatzFixture.solve_max_range (857 ms)
-[----------] 13 tests from CollatzFixture (2739 ms total)
+[       OK ] CollatzFixture.solve_inverse (51 ms)
+[ RUN      ] CollatzFixture.solve_single
+[       OK ] CollatzFixture.solve_single (3 ms)
+[----------] 12 tests from CollatzFixture (328 ms total)
 
 [----------] Global test environment tear-down
-[==========] 13 tests from 1 test case ran. (2786 ms total)
-[  PASSED  ] 13 tests.
-==1511==
-==1511== HEAP SUMMARY:
-==1511==     in use at exit: 72,704 bytes in 1 blocks
-==1511==   total heap usage: 261 allocs, 260 frees, 12,134,885 bytes allocated
-==1511==
-==1511== LEAK SUMMARY:
-==1511==    definitely lost: 0 bytes in 0 blocks
-==1511==    indirectly lost: 0 bytes in 0 blocks
-==1511==      possibly lost: 0 bytes in 0 blocks
-==1511==    still reachable: 72,704 bytes in 1 blocks
-==1511==         suppressed: 0 bytes in 0 blocks
-==1511== Rerun with --leak-check=full to see details of leaked memory
-==1511==
-==1511== For counts of detected and suppressed errors, rerun with: -v
-==1511== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+[==========] 12 tests from 1 test case ran. (376 ms total)
+[  PASSED  ] 12 tests.
+==2433==
+==2433== HEAP SUMMARY:
+==2433==     in use at exit: 72,704 bytes in 1 blocks
+==2433==   total heap usage: 255 allocs, 254 frees, 4,133,481 bytes allocated
+==2433==
+==2433== LEAK SUMMARY:
+==2433==    definitely lost: 0 bytes in 0 blocks
+==2433==    indirectly lost: 0 bytes in 0 blocks
+==2433==      possibly lost: 0 bytes in 0 blocks
+==2433==    still reachable: 72,704 bytes in 1 blocks
+==2433==         suppressed: 0 bytes in 0 blocks
+==2433== Rerun with --leak-check=full to see details of leaked memory
+==2433==
+==2433== For counts of detected and suppressed errors, rerun with: -v
+==2433== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
 File 'Collatz.c++'
-Lines executed:100.00% of 42
-Branches executed:100.00% of 40
-Taken at least once:77.50% of 40
-Calls executed:86.67% of 30
+Lines executed:100.00% of 49
+Branches executed:100.00% of 50
+Taken at least once:72.00% of 50
+Calls executed:75.00% of 36
 Creating 'Collatz.c++.gcov'


### PR DESCRIPTION
I just fixed my unit tests to avoid overflowing ranges.

File .in and .out already meet this prerequisite.